### PR TITLE
Add redirect from URL that was used before

### DIFF
--- a/security-audits/index.html
+++ b/security-audits/index.html
@@ -1,3 +1,6 @@
+---
+redirect_from: "/audit-contact"
+---
 <!DOCTYPE html>
 <html style="height: 100%;">
   <head>


### PR DESCRIPTION
We used to share the URL `/audit-contact` before, which now doesn't work anymore. It is good practice to keep links working always, so I added this redirection.

This isn't ideal because it's not doing an HTTP 301 redirect but an HTML meta redirect, and so it flashes an ugly "Redirecting..." page for an instant.

We can replace that page by a nicer one by adding a file in `_layout/redirect.html` but I didn't want to do that myself.

As far as I could tell, there is no way to do "true" HTTP redirects in GitHub Pages.