### PR TITLE
Change redirection to full canonical link

### DIFF
--- a/audit-contact.html
+++ b/audit-contact.html
@@ -1,0 +1,3 @@
+---
+redirect_to: "https://zeppelin.solutions/security-audits/"
+---

--- a/security-audits/index.html
+++ b/security-audits/index.html
@@ -1,6 +1,3 @@
----
-redirect_from: "/audit-contact"
----
 <!DOCTYPE html>
 <html style="height: 100%;">
   <head>


### PR DESCRIPTION
The redirection introduced in #41 was taking to https://zeppelinsolutions.github.io/zeppelin.solutions/security-audits/.

Added the full link to make up for this and will open a related issue for what I think is the reason.