### PR TITLE
Fix job search links

### DIFF
--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -357,10 +357,10 @@ layout: default
         <div class="job-card">
           <div>
             <h4>{{ job.location | slice: 0, 80 }}</h4>
-            <h1><a href="{{ job.url | absolute_url }}">{{ job.title }}</a></h1>
+            <h1><a href="{{ job.url }}">{{ job.title }}</a></h1>
           </div>
           <div>
-            <a href="{{ job.url | absolute_url }}">
+            <a href="{{ job.url }}">
               <img src="../images/ic_arrow_right_blue.svg"/>
             </a>
           </div>
@@ -373,10 +373,10 @@ layout: default
         <div class="job-card">
           <div>
             <h4>{{ job.location | slice: 0, 80 }}</h4>
-            <h1><a href="{{ job.url | absolute_url }}">{{ job.title }}</a></h1>
+            <h1><a href="{{ job.url }}">{{ job.title }}</a></h1>
           </div>
           <div>
-            <a href="{{ job.url | absolute_url }}">
+            <a href="{{ job.url }}">
               <img src="../images/ic_arrow_right_blue.svg"/>
             </a>
           </div>
@@ -390,10 +390,10 @@ layout: default
         <div class="job-card">
           <div>
             <h4>{{ job.location | slice: 0, 80 }}</h4>
-            <h1><a href="{{ job.url | absolute_url }}">{{ job.title }}</a></h1>
+            <h1><a href="{{ job.url }}">{{ job.title }}</a></h1>
           </div>
           <div>
-            <a href="{{ job.url | absolute_url }}">
+            <a href="{{ job.url }}">
               <img src="../images/ic_arrow_right_blue.svg"/>
             </a>
           </div>


### PR DESCRIPTION
This makes the links relative, so that they also work in Netlify. (e.g: https://deploy-preview-107--zeppelinsolutions.netlify.com/jobs/)